### PR TITLE
Make goreleaser archive to zip format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ config.ign.merged
 .terraform
 coverage.txt
 dist
+
+.idea

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,40 +1,32 @@
 # This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
+project_name: terraform-provider-vagrant
 builds:
-  - binary: terraform-provider-vagrant_v{{ .Version }}
-    env:
-      - CGO_ENABLED=0
+  - binary: '{{ .ProjectName }}_{{ .Version }}'
+    flags:
+      - -trimpath
+    goarch:
+      - '386'
+      - amd64
+      - arm
+      - arm64
     goos:
       - darwin
       - freebsd
       - linux
-      - openbsd
-      - solaris
       - windows
-    goarch:
-      - 386
-      - amd64
-      - arm
     ignore:
-      - goos: darwin
-        goarch: 386
-      - goos: darwin
-        goarch: arm
-      - goos: openbsd
-        goarch: arm
-      - goos: solaris
-        goarch: 386
-      - goos: solaris
-        goarch: arm
-      - goos: windows
-        goarch: arm
-archive:
-  name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
-  format_overrides:
-    - goos: windows
-      format: zip
+      - goarch: '386'
+        goos: darwin
+    ldflags:
+      - -s -w -X version.ProviderVersion={{.Version}}
+    mod_timestamp: '{{ .CommitTimestamp }}'
+archives:
+  - name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    format: zip
 checksum:
-  name_template: 'checksums.txt'
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
@@ -43,3 +35,5 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+env:
+  - CGO_ENABLED=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: go
 
 go:
-  - 1.13
+  - 1.16


### PR DESCRIPTION
When using MacOs and Terraform >= 0.13 I get an error complaining about not finding the zip archive for the provider on the registry.
This might fix it. Not sure if it is related to the archive being tar.gz by default or in the change to the archive naming convention.

I based the changes on the goreleaser configs used by terraform-provider-aws.
﻿
