### PR TITLE
Adding basic support for specifying create timeout.

### DIFF
--- a/resource_vagrant_vm.go
+++ b/resource_vagrant_vm.go
@@ -34,6 +34,10 @@ func resourceVagrantVM() *schema.Resource {
 			}),
 		),
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(VagrantVMCreatedTimeout),
+		},
+
 		SchemaVersion: 1,
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -157,7 +161,8 @@ func resourceVagrantVMCreate(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(err)
 	}
 
-	log.Println("Bringing up vagrant...")
+	log.Println(fmt.Sprintf("Bringing up vagrant... (timeout %s)", d.Timeout(schema.TimeoutCreate)))
+
 	cmd := client.Up()
 	cmd.Context = ctx
 	cmd.Env = buildEnvironment(d.Get("env").(map[string]interface{}))

--- a/vagrant_config.go
+++ b/vagrant_config.go
@@ -1,5 +1,12 @@
 package main
 
+import "time"
+
+// Default timeout values for vagrant VM resource creation
+const (
+	VagrantVMCreatedTimeout = 2 * time.Minute
+)
+
 // VagrantConfig is for provider-level configuration.
 type VagrantConfig struct {
 }


### PR DESCRIPTION
For me the Vagrant VMs were never building before apparently being timed out by terraform.   My golang knowledge is rudimentary, to say the least, but I examined how this was implemented for another provider and got a version that appears to work (respecting the configured timeout values).

Happy to update the docs too, if you're amenable to this PR.